### PR TITLE
Load event series newest-first and across all pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,16 +95,14 @@ def get_event_series(source_api_key):
                 break
             params = {'limit': 100, 'starting_after': page[-1]['id']}
 
-        # Sort newest -> oldest. created_at is a unix timestamp on each series;
-        # fall back to id ordering if it is missing.
+        # Sort newest -> oldest by created_at (a unix timestamp on each series).
+        # Always return an int so mixed-type comparisons can't crash the sort;
+        # series with a missing/invalid created_at fall to the end.
         def sort_key(series):
-            created = series.get('created_at')
-            if created is not None:
-                try:
-                    return int(created)
-                except (ValueError, TypeError):
-                    pass
-            return series.get('id', '')
+            try:
+                return int(series.get('created_at'))
+            except (ValueError, TypeError):
+                return 0
 
         all_series.sort(key=sort_key, reverse=True)
         return all_series

--- a/app.py
+++ b/app.py
@@ -65,16 +65,49 @@ def format_data_for_api(data):
     return formatted_data
 
 def get_event_series(source_api_key):
-    """Fetch event series from source box office"""
+    """Fetch all event series from source box office, newest first.
+
+    The Ticket Tailor API returns event series in pages (oldest first).
+    Previously we only returned the first page in the API's default order,
+    which meant a newer event the user wanted to copy could be pushed off
+    the list entirely. We now walk every page and sort newest -> oldest so
+    the most recent series are always shown at the top and reachable.
+    """
     try:
         url = f"{TICKET_TAILOR_API_BASE}/event_series"
-        response = make_api_request('GET', url, source_api_key)
-        response.raise_for_status()
-        data = response.json()
-        # Handle pagination if needed
-        if 'data' in data:
-            return data['data']
-        return data
+        all_series = []
+        params = {'limit': 100}
+
+        while True:
+            response = make_api_request('GET', url, source_api_key, params=params)
+            response.raise_for_status()
+            data = response.json()
+
+            page = data['data'] if isinstance(data, dict) and 'data' in data else data
+            if not page:
+                break
+
+            all_series.extend(page)
+
+            # Cursor pagination: request the next page using the last id we saw.
+            # Stop once a page returns fewer than the requested limit.
+            if len(page) < params['limit']:
+                break
+            params = {'limit': 100, 'starting_after': page[-1]['id']}
+
+        # Sort newest -> oldest. created_at is a unix timestamp on each series;
+        # fall back to id ordering if it is missing.
+        def sort_key(series):
+            created = series.get('created_at')
+            if created is not None:
+                try:
+                    return int(created)
+                except (ValueError, TypeError):
+                    pass
+            return series.get('id', '')
+
+        all_series.sort(key=sort_key, reverse=True)
+        return all_series
     except requests.exceptions.RequestException as e:
         if hasattr(e.response, 'text'):
             error_msg = f"API Error: {e.response.text}"


### PR DESCRIPTION
## Problem

A user gave feedback that loading event series oldest → newest meant the event they wanted to copy was unavailable (which they found frustrating). `get_event_series` fetched `/event_series` a single time and returned whatever page/order the Ticket Tailor API produced — oldest-first, one page. A newer series could be sorted to the bottom or pushed off the returned page entirely.

## Change

- **Paginate through all series** using cursor pagination (`starting_after` + `limit=100`) instead of returning just the first page.
- **Sort newest → oldest** by `created_at` (unix timestamp), falling back to id ordering if the field is missing.

The template needs no change — it renders whatever order the endpoint returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Listing may trigger many sequential API calls for large catalogs, increasing latency and load on the Ticket Tailor API without changing copy or auth behavior.
> 
> **Overview**
> **`get_event_series`** no longer returns only the first Ticket Tailor `/event_series` page in the API’s default oldest-first order. It now **loops through every page** with cursor pagination (`limit=100`, `starting_after` on the last id) and **sorts the combined list newest → oldest** by `created_at`, with invalid or missing timestamps pushed to the end.
> 
> The **`/api/event-series`** route is unchanged; the UI gets a full, recency-ordered list so newer series are visible and selectable for copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7985dad029d50b042400ca4b430f45950e38896f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->